### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-commit-checker.yml
+++ b/.github/workflows/github-actions-commit-checker.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Check Description Length
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[^\n]{7,50}(?:\n(?:\n[^\n]{0,72})+)?$'
+          pattern: '^[^\n]{7,50}(?:\n(?:\n([^\n]{0,72}|Co-authored-by:.+))+)?$'
           flags: g
           error: '
             The body can have a longer description than the subject,

--- a/.github/workflows/github-actions-commit-checker.yml
+++ b/.github/workflows/github-actions-commit-checker.yml
@@ -1,4 +1,6 @@
 name: Lint commit
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/darakeon/dfm/security/code-scanning/30](https://github.com/darakeon/dfm/security/code-scanning/30)

In general, to fix this issue you should declare a `permissions:` block either at the top (workflow level, applying to all jobs) or under the specific job, restricting `GITHUB_TOKEN` to the least privileges required. For this workflow, the commit message checker action only needs to read pull requests and commits; it does not need to write to contents or other resources. Therefore, we can safely set `contents: read` at the workflow (or job) level. Optionally, you could also add `pull-requests: read`, but `contents: read` is sufficient for reading commits in most setups.

The single best fix with minimal behavior change is to add a workflow-level `permissions:` block right after the `name:` line, before the `on:` block, so it applies to all jobs that don’t override it. We will set `contents: read` as the least-privilege default. No imports, methods, or additional definitions are needed because this is a pure YAML configuration change within `.github/workflows/github-actions-commit-checker.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
