### PR TITLE
Force android publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2149,4 +2149,7 @@ workflows:
             - test_android_lib_release
             - test_android_app_debug
             - test_android_app_release
+      - workflow_ran:
+          requires:
+            - publish_android
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2143,12 +2143,16 @@ workflows:
       - test_android_app_release:
           requires:
             - build_android
-      - publish_android:
+      - approve_deploy:
+          type: approval
           requires:
             - test_android_lib_debug
             - test_android_lib_release
             - test_android_app_debug
             - test_android_app_release
+      - publish_android:
+          requires:
+            - approve_deploy
       - workflow_ran:
           requires:
             - publish_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2114,3 +2114,39 @@ workflows:
               only:
                 - main
                 - /^\d+\.\d+\.\d+\.\d+$/
+  android_publish:
+    jobs:
+      - trufflehog:
+          filters:
+            branches:
+              only:
+                - android-publish
+      - test_ci:
+          requires:
+            - trufflehog
+      - push_docker_android:
+          requires:
+            - test_ci
+      - build_android:
+          requires:
+            - test_ci
+            - push_docker_android
+      - test_android_lib_debug:
+          requires:
+            - build_android
+      - test_android_lib_release:
+          requires:
+            - build_android
+      - test_android_app_debug:
+          requires:
+            - build_android
+      - test_android_app_release:
+          requires:
+            - build_android
+      - publish_android:
+          requires:
+            - test_android_lib_debug
+            - test_android_lib_release
+            - test_android_app_debug
+            - test_android_app_release
+

--- a/.circleci/pieces/Z13-workflow-android-publish.yml
+++ b/.circleci/pieces/Z13-workflow-android-publish.yml
@@ -1,0 +1,36 @@
+  android_publish:
+    jobs:
+      - trufflehog:
+          filters:
+            branches:
+              only:
+                - android-publish
+      - test_ci:
+          requires:
+            - trufflehog
+      - push_docker_android:
+          requires:
+            - test_ci
+      - build_android:
+          requires:
+            - test_ci
+            - push_docker_android
+      - test_android_lib_debug:
+          requires:
+            - build_android
+      - test_android_lib_release:
+          requires:
+            - build_android
+      - test_android_app_debug:
+          requires:
+            - build_android
+      - test_android_app_release:
+          requires:
+            - build_android
+      - publish_android:
+          requires:
+            - test_android_lib_debug
+            - test_android_lib_release
+            - test_android_app_debug
+            - test_android_app_release
+

--- a/.circleci/pieces/Z13-workflow-android-publish.yml
+++ b/.circleci/pieces/Z13-workflow-android-publish.yml
@@ -33,4 +33,7 @@
             - test_android_lib_release
             - test_android_app_debug
             - test_android_app_release
+      - workflow_ran:
+          requires:
+            - publish_android
 

--- a/.circleci/pieces/Z13-workflow-android-publish.yml
+++ b/.circleci/pieces/Z13-workflow-android-publish.yml
@@ -27,12 +27,16 @@
       - test_android_app_release:
           requires:
             - build_android
-      - publish_android:
+      - approve_deploy:
+          type: approval
           requires:
             - test_android_lib_debug
             - test_android_lib_release
             - test_android_app_debug
             - test_android_app_release
+      - publish_android:
+          requires:
+            - approve_deploy
       - workflow_ran:
           requires:
             - publish_android

--- a/android/App/build.gradle
+++ b/android/App/build.gradle
@@ -14,7 +14,7 @@ android {
 		// read the explanation
 		// at the end of the file
 		//noinspection HighAppVersionCode
-		versionCode 2011000077
+		versionCode 2011000078
 		versionName "$dfm_version"
 
 		minSdkVersion 23


### PR DESCRIPTION
This branch was created because android demands a frequency of publishes to maintain developer accounts. Because of that, I had to make a new forced deploy.

On the other hand, everytime the libs change the app should've been deployed. This must be also fixed.